### PR TITLE
Fix boolean checks in combo popup and scrollbar

### DIFF
--- a/src/main/java/ch/randelshofer/quaqua/QuaquaComboPopup.java
+++ b/src/main/java/ch/randelshofer/quaqua/QuaquaComboPopup.java
@@ -697,8 +697,8 @@ public class QuaquaComboPopup extends BasicComboPopup {
 				}
 			} else if (propertyName == "lightWeightPopupEnabled") {
 				setLightWeightPopupEnabled(comboBox.isLightWeightPopupEnabled());
-			} else if (propertyName.equals("renderer") || propertyName.equals(QuaquaComboBoxUI.IS_TABLE_CELL_EDITOR)) {
-				updateCellRenderer(e.getNewValue().equals(Boolean.TRUE));
+                        } else if (propertyName.equals("renderer") || propertyName.equals(QuaquaComboBoxUI.IS_TABLE_CELL_EDITOR)) {
+                                updateCellRenderer(Boolean.TRUE.equals(e.getNewValue()));
 			} else if (propertyName.equals("JComboBox.lightweightKeyboardNavigation")) {
 				// In Java 1.3 we have to use this property to guess whether we
 				// are a table cell editor or not.

--- a/src/main/java/ch/randelshofer/quaqua/QuaquaScrollBarUI.java
+++ b/src/main/java/ch/randelshofer/quaqua/QuaquaScrollBarUI.java
@@ -69,12 +69,12 @@ public class QuaquaScrollBarUI extends BasicScrollBarUI {
 	}
 
 	private void updatePlaceButtonsTogether() {
-		Object value = scrollbar.getClientProperty("Quaqua.ScrollBar.placeButtonsTogether");
-		if (value == null) {
-			isPlaceButtonsTogether = UIManager.getBoolean("ScrollBar.placeButtonsTogether");
-		} else {
-			isPlaceButtonsTogether = value.equals(Boolean.TRUE);
-		}
+                Object value = scrollbar.getClientProperty("Quaqua.ScrollBar.placeButtonsTogether");
+                if (value == null) {
+                        isPlaceButtonsTogether = UIManager.getBoolean("ScrollBar.placeButtonsTogether");
+                } else {
+                        isPlaceButtonsTogether = Boolean.TRUE.equals(value);
+                }
 	}
 
 	private boolean isPlaceButtonsTogether() {


### PR DESCRIPTION
## Summary
- avoid NPE when combo popup updates renderer
- handle null safely in scrollbar option logic

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7825317c83329ec70d38806f5146