### PR TITLE
Fix filesize calculations

### DIFF
--- a/src/main/java/ch/randelshofer/quaqua/lion/filechooser/LionFilePreview.java
+++ b/src/main/java/ch/randelshofer/quaqua/lion/filechooser/LionFilePreview.java
@@ -250,15 +250,15 @@ public class LionFilePreview extends JPanel implements BrowserPreviewRenderer {
 		} else {
 			float scaledLength;
 			String label;
-			if (fileLength >= 1000000000l) {
-				label = "FileChooser.sizeGBytesOnly";
-				scaledLength = (float) fileLength / 1000000000l;
-			} else if (fileLength >= 1000000l) {
-				label = "FileChooser.sizeMBytesOnly";
-				scaledLength = (float) fileLength / 1000000l;
-			} else if (fileLength >= 1024) {
-				label = "FileChooser.sizeKBytesOnly";
-				scaledLength = (float) fileLength / 1000;
+                        if (fileLength >= 1024L * 1024L * 1024L) {
+                                label = "FileChooser.sizeGBytesOnly";
+                                scaledLength = (float) fileLength / (1024f * 1024f * 1024f);
+                        } else if (fileLength >= 1024L * 1024L) {
+                                label = "FileChooser.sizeMBytesOnly";
+                                scaledLength = (float) fileLength / (1024f * 1024f);
+                        } else if (fileLength >= 1024) {
+                                label = "FileChooser.sizeKBytesOnly";
+                                scaledLength = (float) fileLength / 1024f;
 			} else {
 				label = "FileChooser.sizeBytesOnly";
 				scaledLength = fileLength;

--- a/src/main/java/ch/randelshofer/quaqua/lion/filechooser/ListView.java
+++ b/src/main/java/ch/randelshofer/quaqua/lion/filechooser/ListView.java
@@ -429,15 +429,15 @@ public class ListView extends ch.randelshofer.quaqua.filechooser.ListView {
 		} else {
 			float scaledLength;
 			String label;
-			if (fileLength >= 1000000000l) {
-				label = "FileChooser.sizeGBytesOnly";
-				scaledLength = (float) fileLength / 1000000000l;
-			} else if (fileLength >= 1000000l) {
-				label = "FileChooser.sizeMBytesOnly";
-				scaledLength = (float) fileLength / 1000000l;
-			} else if (fileLength >= 1024) {
-				label = "FileChooser.sizeKBytesOnly";
-				scaledLength = (float) fileLength / 1000;
+                        if (fileLength >= 1024L * 1024L * 1024L) {
+                                label = "FileChooser.sizeGBytesOnly";
+                                scaledLength = (float) fileLength / (1024f * 1024f * 1024f);
+                        } else if (fileLength >= 1024L * 1024L) {
+                                label = "FileChooser.sizeMBytesOnly";
+                                scaledLength = (float) fileLength / (1024f * 1024f);
+                        } else if (fileLength >= 1024) {
+                                label = "FileChooser.sizeKBytesOnly";
+                                scaledLength = (float) fileLength / 1024f;
 			} else {
 				label = "FileChooser.sizeBytesOnly";
 				scaledLength = fileLength;


### PR DESCRIPTION
## Summary
- fix filesize calculations in Lion file chooser preview and list view
- use 1024-based units for KB, MB and GB

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7c64fc18833298113a12f29617fc